### PR TITLE
Some fixes for modern kernels

### DIFF
--- a/drivers/dma/Makefile
+++ b/drivers/dma/Makefile
@@ -18,7 +18,7 @@
 
 # Cross-compile for ARM by default.
 ARCH?=arm
-CROSS_COMPILE?=arm-linux-gnueabi-
+CROSS_COMPILE?=arm-linux-gnueabihf-
 
 # If desired, you can specify a default KERNELDIR by uncommenting the line
 # below and placing your desired directory after the ?=

--- a/drivers/dma/ezdma.c
+++ b/drivers/dma/ezdma.c
@@ -29,7 +29,7 @@
 #include <asm/param.h>  /* HZ */
 #include <linux/semaphore.h>
 #include <linux/mutex.h>
-#include <linux/pagemap.h>
+#include <linux/mm.h>
 
 #include <linux/dmaengine.h>
 #include <linux/dma-mapping.h>
@@ -428,7 +428,7 @@ static void ezdma_unprepare_after_dma( struct ezdma_drvdata * p_info )
                 struct page * const page = p_info->inflight.pinned_pages[i];
 
                 set_page_dirty( page );
-                page_cache_release( page );
+                put_page( page );
             }
         }
     }

--- a/examples/loopback/c/Makefile
+++ b/examples/loopback/c/Makefile
@@ -1,19 +1,23 @@
 
 CC=gcc
 CFLAGS=-O2
+LDFLAGS=
 
 all: ezdma_send ezdma_receive ezdma_speed_test
 
-ezdma_receive: ezdma_receive.c
-	$(CC) $(CFLAGS) -o $@ $<
+ezdma_receive: stream_shared.o ezdma_receive.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
-ezdma_send: ezdma_send.c
-	$(CC) $(CFLAGS) -o $@ $<
+ezdma_send: stream_shared.o ezdma_send.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 ezdma_speed_test: ezdma_speed_test.c
 	$(CC) $(CFLAGS) -o $@ $<
 
+%.o: %c
+	$(CC) $(CFLAGS) -c $<
+
 clean:
-	rm -f ezdma_speed_test ezdma_send ezdma_receive
+	rm -f ezdma_speed_test ezdma_send ezdma_receive stream_shared.o ezdma_send.o ezdma_receive.o
 
 .PHONY: clean

--- a/examples/loopback/c/Makefile
+++ b/examples/loopback/c/Makefile
@@ -1,0 +1,19 @@
+
+CC=gcc
+CFLAGS=-O2
+
+all: ezdma_send ezdma_receive ezdma_speed_test
+
+ezdma_receive: ezdma_receive.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+ezdma_send: ezdma_send.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+ezdma_speed_test: ezdma_speed_test.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+clean:
+	rm -f ezdma_speed_test ezdma_send ezdma_receive
+
+.PHONY: clean

--- a/examples/loopback/c/ezdma_receive.c
+++ b/examples/loopback/c/ezdma_receive.c
@@ -1,6 +1,7 @@
 /*
-ezdma loopback speed test
+ezdma loopback stream receiver
 Copyright (C) 2015 Jeremy Trimble
+Copyright (C) 2016 Jan Binder
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -27,6 +28,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 const int NUM_TRIALS = 100000;
 
+//<#define PACKET_SIZE (2048)
 #define PACKET_SIZE (4096)
 
 uint8_t tx_buf[PACKET_SIZE];
@@ -37,44 +39,36 @@ int main(int argc, char *argv[])
     struct timespec tick, tock;
     int i;
 
-    int tx_fd = open("/dev/loop_tx", O_WRONLY);
     int rx_fd = open("/dev/loop_rx", O_RDONLY);
 
-    if ( tx_fd < 0 || rx_fd < 0 )
+    if ( rx_fd < 0 )
     {
-        perror("can't open loop devices\n");
+        perror("can't open receive loop device\n");
         return 2;
     }
 
     for (i = 0; i < PACKET_SIZE; ++i)
         tx_buf[i] = i; // automatically mod-256
 
-    assert( !clock_gettime(CLOCK_MONOTONIC, &tick) );
 
     i = 0;
     while ( i < NUM_TRIALS )
     {
         //printf("trial %d\n", i);
-        assert( PACKET_SIZE == write(tx_fd, tx_buf, PACKET_SIZE) );
         assert( PACKET_SIZE == read (rx_fd, rx_buf, PACKET_SIZE) );
-        //{
-        //int rv = read (rx_fd, rx_buf, PACKET_SIZE);
-        //printf("read returned %d\n", rv);
-        //}
+        if ( i == 0 )
+            assert( !clock_gettime(CLOCK_MONOTONIC, &tick) );
 
+        int j;
+        for (j = 0; j < PACKET_SIZE; ++j)
         {
-            int j;
-            for (j = 0; j < PACKET_SIZE; ++j)
+            if ( rx_buf[j] != tx_buf[j] )
             {
-                if ( rx_buf[j] != tx_buf[j] )
-                {
-                    printf("ERROR IN DATA\n");
-                    printf("  @ j=%d: rx_buf[%d]: %u, tx_buf[%d]: %u\n",
-                        j, j, rx_buf[j], j, tx_buf[j]);
-                    return 2;
-                }
+                printf("ERROR IN DATA\n");
+                printf("  @ j=%d: rx_buf[%d]: %u, tx_buf[%d]: %u\n",
+                    j, j, rx_buf[j], j, tx_buf[j]);
+                return 2;
             }
-
         }
 
         tx_buf[i % PACKET_SIZE] += 5;  // modify data each time
@@ -86,7 +80,7 @@ int main(int argc, char *argv[])
 
     {
         double start, end, diff, bytes_per_sec;
-        double numBytes = (double)NUM_TRIALS * PACKET_SIZE;
+        double numBytes = (double)(NUM_TRIALS - 1) * PACKET_SIZE;
 
         start = tick.tv_sec + tick.tv_nsec/1e9;
         end   = tock.tv_sec + tock.tv_nsec/1e9;
@@ -94,10 +88,10 @@ int main(int argc, char *argv[])
 
         bytes_per_sec = numBytes / (double)(1<<20) / diff;
 
-        printf("sent %d %d-byte packets in %.9f sec: %.3f MB/s\n",
-                NUM_TRIALS, PACKET_SIZE, diff, bytes_per_sec);
+        printf("received %d %d-byte packets in %.9f sec: %.3f MB/s\n",
+                NUM_TRIALS - 1, PACKET_SIZE, diff, bytes_per_sec);
     }
-    
+ 
     return 0;
 }
 

--- a/examples/loopback/c/ezdma_send.c
+++ b/examples/loopback/c/ezdma_send.c
@@ -1,6 +1,7 @@
 /*
-ezdma loopback speed test
+ezdma loopback stream sender
 Copyright (C) 2015 Jeremy Trimble
+Copyright (C) 2016 Jan Binder
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -30,7 +31,6 @@ const int NUM_TRIALS = 100000;
 #define PACKET_SIZE (4096)
 
 uint8_t tx_buf[PACKET_SIZE];
-uint8_t rx_buf[PACKET_SIZE];
 
 int main(int argc, char *argv[])
 {
@@ -38,11 +38,10 @@ int main(int argc, char *argv[])
     int i;
 
     int tx_fd = open("/dev/loop_tx", O_WRONLY);
-    int rx_fd = open("/dev/loop_rx", O_RDONLY);
 
-    if ( tx_fd < 0 || rx_fd < 0 )
+    if ( tx_fd < 0 )
     {
-        perror("can't open loop devices\n");
+        perror("can't open sender loop device\n");
         return 2;
     }
 
@@ -56,29 +55,7 @@ int main(int argc, char *argv[])
     {
         //printf("trial %d\n", i);
         assert( PACKET_SIZE == write(tx_fd, tx_buf, PACKET_SIZE) );
-        assert( PACKET_SIZE == read (rx_fd, rx_buf, PACKET_SIZE) );
-        //{
-        //int rv = read (rx_fd, rx_buf, PACKET_SIZE);
-        //printf("read returned %d\n", rv);
-        //}
-
-        {
-            int j;
-            for (j = 0; j < PACKET_SIZE; ++j)
-            {
-                if ( rx_buf[j] != tx_buf[j] )
-                {
-                    printf("ERROR IN DATA\n");
-                    printf("  @ j=%d: rx_buf[%d]: %u, tx_buf[%d]: %u\n",
-                        j, j, rx_buf[j], j, tx_buf[j]);
-                    return 2;
-                }
-            }
-
-        }
-
         tx_buf[i % PACKET_SIZE] += 5;  // modify data each time
-
         i++;
     }
 
@@ -97,7 +74,7 @@ int main(int argc, char *argv[])
         printf("sent %d %d-byte packets in %.9f sec: %.3f MB/s\n",
                 NUM_TRIALS, PACKET_SIZE, diff, bytes_per_sec);
     }
-    
+
     return 0;
 }
 

--- a/examples/loopback/c/ezdma_send.c
+++ b/examples/loopback/c/ezdma_send.c
@@ -26,9 +26,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include <unistd.h>
 #include <assert.h>
 
-const int NUM_TRIALS = 100000;
-
-#define PACKET_SIZE (4096)
+#include "stream_shared.h"
 
 uint8_t tx_buf[PACKET_SIZE];
 
@@ -45,37 +43,21 @@ int main(int argc, char *argv[])
         return 2;
     }
 
-    for (i = 0; i < PACKET_SIZE; ++i)
-        tx_buf[i] = i; // automatically mod-256
+    prepare_tx_buffer(&tx_buf);
 
     assert( !clock_gettime(CLOCK_MONOTONIC, &tick) );
-
-    i = 0;
-    while ( i < NUM_TRIALS )
+    printf("Sending %d %d-byte packets\n", NUM_TRIALS, PACKET_SIZE);
+    for (i = 0; i < NUM_TRIALS; ++i)
     {
         //printf("trial %d\n", i);
         assert( PACKET_SIZE == write(tx_fd, tx_buf, PACKET_SIZE) );
-        tx_buf[i % PACKET_SIZE] += 5;  // modify data each time
-        i++;
+        change_tx_buffer(&tx_buf, i);
     }
 
     assert( !clock_gettime(CLOCK_MONOTONIC, &tock) );
 
-    {
-        double start, end, diff, bytes_per_sec;
-        double numBytes = (double)NUM_TRIALS * PACKET_SIZE;
-
-        start = tick.tv_sec + tick.tv_nsec/1e9;
-        end   = tock.tv_sec + tock.tv_nsec/1e9;
-        diff  = end - start;
-
-        bytes_per_sec = numBytes / (double)(1<<20) / diff;
-
-        printf("sent %d %d-byte packets in %.9f sec: %.3f MB/s\n",
-                NUM_TRIALS, PACKET_SIZE, diff, bytes_per_sec);
-    }
+    print_throughput(&tick, &tock);
 
     return 0;
 }
-
 

--- a/examples/loopback/c/ezdma_speed_test.c
+++ b/examples/loopback/c/ezdma_speed_test.c
@@ -29,9 +29,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
    make CFLAGS=-O2 LDFLAGS+=-lrt ezdma_speed_test
  */
 
-const int NUM_TRIALS = 10000;
+const int NUM_TRIALS = 100000;
 
-#define PACKET_SIZE (2048)
+#define PACKET_SIZE (4096)
 
 uint8_t tx_buf[PACKET_SIZE];
 uint8_t rx_buf[PACKET_SIZE];
@@ -55,8 +55,10 @@ int main(int argc, char *argv[])
 
     assert( !clock_gettime(CLOCK_MONOTONIC, &tick) );
 
+    i = 0;
     while ( i < NUM_TRIALS )
     {
+        //printf("trial %d\n", i);
         assert( PACKET_SIZE == write(tx_fd, tx_buf, PACKET_SIZE) );
         assert( PACKET_SIZE == read (rx_fd, rx_buf, PACKET_SIZE) );
         //{
@@ -87,16 +89,16 @@ int main(int argc, char *argv[])
     assert( !clock_gettime(CLOCK_MONOTONIC, &tock) );
 
     {
-        float start, end, diff, bytes_per_sec;
-        float numBytes = (float)NUM_TRIALS * PACKET_SIZE;
+        double start, end, diff, bytes_per_sec;
+        double numBytes = (double)NUM_TRIALS * PACKET_SIZE;
 
         start = tick.tv_sec + tick.tv_nsec/1e9;
         end   = tock.tv_sec + tock.tv_nsec/1e9;
         diff  = end - start;
 
-        bytes_per_sec = numBytes / (1<<20) / diff;
+        bytes_per_sec = numBytes / (double)(1<<20) / diff;
 
-        printf("sent %d %d-byte packets in %.3f sec: %.3f MB/s\n",
+        printf("sent %d %d-byte packets in %.9f sec: %.3f MB/s\n",
                 NUM_TRIALS, PACKET_SIZE, diff, bytes_per_sec);
     }
     

--- a/examples/loopback/c/ezdma_stream_test.sh
+++ b/examples/loopback/c/ezdma_stream_test.sh
@@ -3,6 +3,8 @@
 ./ezdma_receive &
 RECV_PID=$!
 
+sleep 0.1
+
 ./ezdma_send
 
 wait $RECV_PID

--- a/examples/loopback/c/ezdma_stream_test.sh
+++ b/examples/loopback/c/ezdma_stream_test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+./ezdma_receive &
+RECV_PID=$!
+
+./ezdma_send
+
+wait $RECV_PID

--- a/examples/loopback/c/stream_shared.c
+++ b/examples/loopback/c/stream_shared.c
@@ -1,0 +1,66 @@
+/*
+ezdma speedtest shared functions
+Copyright (C) 2015 Jeremy Trimble
+Copyright (C) 2016 Jan Binder
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include "stream_shared.h"
+
+const int NUM_TRIALS = 100000;
+
+void prepare_tx_buffer(uint8_t (*tx_buf)[PACKET_SIZE])
+{
+    int i;
+    for (i = 0; i < PACKET_SIZE; ++i)
+        (*tx_buf)[i] = i; // automatically mod-256
+}
+
+void change_tx_buffer(uint8_t (*tx_buf)[PACKET_SIZE], int i)
+{
+    (*tx_buf)[i % PACKET_SIZE] += 5;  // modify data each time
+}
+
+int check_buffer(uint8_t (*rx_buf)[PACKET_SIZE], uint8_t (*tx_buf)[PACKET_SIZE])
+{
+    int i;
+    for (i = 0; i < PACKET_SIZE; ++i)
+    {
+        if ( (*rx_buf)[i] != (*tx_buf)[i] )
+        {
+            printf("ERROR IN DATA\n");
+            printf("  @ i=%d: rx_buf[%d]: %u, tx_buf[%d]: %u\n",
+                i, i, (*rx_buf)[i], i, (*tx_buf)[i]);
+            return 2;
+        }
+    }
+    return 0;
+}
+
+void print_throughput(struct timespec *tick, struct timespec *tock)
+{
+    double start, end, diff, bytes_per_sec;
+    double numBytes = (double)NUM_TRIALS * PACKET_SIZE;
+    start = tick->tv_sec + tick->tv_nsec/1e9;
+    end   = tock->tv_sec + tock->tv_nsec/1e9;
+    diff  = end - start;
+
+    bytes_per_sec = numBytes / (double)(1<<20) / diff;
+
+    printf("sent %d %d-byte packets in %.9f sec: %.3f MB/s\n",
+            NUM_TRIALS, PACKET_SIZE, diff, bytes_per_sec);
+}
+

--- a/examples/loopback/c/stream_shared.h
+++ b/examples/loopback/c/stream_shared.h
@@ -1,0 +1,18 @@
+/* Shared values for stream speed test */
+
+#ifndef STREAM_SHARED_H
+#define STREAM_SHARED_H
+
+#include <time.h>
+#include <stdint.h>
+
+#define PACKET_SIZE (4096)
+
+extern const int NUM_TRIALS;
+void prepare_tx_buffer(uint8_t (*tx_buf)[PACKET_SIZE]);
+void change_tx_buffer(uint8_t (*tx_buf)[PACKET_SIZE], int i);
+int check_buffer(uint8_t (*rx_buf)[PACKET_SIZE],  uint8_t (*tx_buf)[PACKET_SIZE]);
+void print_throughput(struct timespec *tick, struct timespec *tock);
+
+#endif // STREAM_SHARED_H
+

--- a/examples/loopback/dts/ezdma_loopback.dtsi
+++ b/examples/loopback/dts/ezdma_loopback.dtsi
@@ -2,14 +2,16 @@
     /* Loopback DMA setup */
     
     loopback_dma: axidma@40400000 {
+        compatible = "xlnx,axi-dma-1.00.a";
         #dma-cells = <1>;
-        compatible = "xlnx,axi-dma";
         reg = < 0x40400000 0x10000 >;
-
+        clocks = <&clkc 15>, <&clkc 15>, <&clkc 15>, <&clkc 15>; // fclk0 from clock controller
+        clock-names = "s_axi_lite_aclk", "m_axi_mm2s_aclk", "m_axi_s2mm_aclk", "m_axi_sg_aclk";
         xlnx,include-sg;
+
         loopback_dma_mm2s_chan: dma-channel@40400000 {
             compatible = "xlnx,axi-dma-mm2s-channel";
-            interrupt-parent = <&gic>;
+            interrupt-parent = <&intc>;
             interrupts = <0 31 4>;  // concat port 2
                                     // IRQ_F2P[15:0] == [91:84],[68:61]
                                     // 2 -> 63 -> 63 - 32 = 31
@@ -22,7 +24,7 @@
 
         loopback_dma_s2mm_chan: dma-channel@40400030 {
             compatible = "xlnx,axi-dma-s2mm-channel";
-            interrupt-parent = <&gic>;
+            interrupt-parent = <&intc>;
             interrupts = <0 32 4>;  // concat port 3 
                                     // IRQ_F2P[15:0] == [91:84],[68:61]
                                     // 3 -> 64 -> 64 - 32 = 32


### PR DESCRIPTION
A few changes that will allow people to run this driver on the latest reference kernels with the reference devicetree from Xilinx and Analog Devices.

Tested on a ZedBoard with Linux 4.6 kernels from Xilinx and Analog Devices.